### PR TITLE
Custom node style override support

### DIFF
--- a/Assets/Examples/BasicExample.asset
+++ b/Assets/Examples/BasicExample.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   - type: FloatNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"3327402b-5ad1-4564-af17-2025a850d4bb","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":242.0,"y":101.0,"width":73.0,"height":101.0},"expanded":false,"debug":false,"output":4.0}'
   - type: MultiAddNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"9a1c513a-65bc-4906-83b7-4a7b66699064","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":497.6956481933594,"y":164.2720489501953,"width":149.0,"height":97.0},"expanded":false,"debug":false,"output":0.0}'
+    jsonDatas: '{"GUID":"9a1c513a-65bc-4906-83b7-4a7b66699064","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":406.8500061035156,"y":121.50003051757813,"width":123.00001525878906,"height":101.0},"expanded":false,"debug":false,"output":0.0}'
   - type: SubNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"95bce55f-47d9-4c5d-bdcd-1f5bbbf57d1b","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":710.0,"y":200.0,"width":99.0,"height":101.0},"expanded":false,"debug":false,"inputA":0.0,"inputB":8.0,"output":-8.0}'
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
@@ -26,7 +26,7 @@ MonoBehaviour:
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"6398414c-0e45-44d7-a62f-3267016dbca1","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":236.43923950195313,"y":-42.947715759277347,"width":99.0,"height":115.0},"expanded":false,"debug":false}'
   - type: PrefabNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"ffd2cf4b-87c3-42a6-9822-04bae7a5700b","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":478.04730224609377,"y":-235.4877471923828,"width":136.0,"height":223.00001525878907},"expanded":true,"debug":false,"output":{"instanceID":11284}}'
+    jsonDatas: '{"GUID":"ffd2cf4b-87c3-42a6-9822-04bae7a5700b","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":478.04730224609377,"y":-235.4877471923828,"width":136.0,"height":223.00001525878907},"expanded":true,"debug":false,"output":{"instanceID":0}}'
   - type: FloatNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"e99da4fb-6a11-4b19-8594-f37f55d96114","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":245.83782958984376,"y":237.15869140625,"width":107.0,"height":117.0},"expanded":false,"debug":false,"output":12.0}'
   - type: TextNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
@@ -36,6 +36,9 @@ MonoBehaviour:
     jsonDatas: '{"GUID":"e277d5c6-386e-4f6b-bd63-af2353f3e4d8","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":68.76971435546875,"y":94.11068725585938,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
   - type: FloatNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"34e17a0c-9187-47eb-a21c-d105ee6ed911","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":506.0,"y":309.04254150390627,"width":107.0,"height":117.0},"expanded":true,"debug":false,"output":8.0}'
+  - type: ParameterNode, com.alelievr.NodeGraphProcessor, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+    jsonDatas: '{"GUID":"eb62aec1-6b04-49a1-89c4-27d66f83289d","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":631.0,"y":6.160011291503906,"width":88.0,"height":77.0},"expanded":false,"debug":false,"parameterGUID":"4f5bc9d8-e5d3-4935-8d09-5cf903694414"}'
   edges:
   - GUID: 04cee6c7-b233-40e1-b41a-31f6093f1482
     owner: {fileID: 11400000}
@@ -50,22 +53,6 @@ MonoBehaviour:
     inputNodeGUID: e277d5c6-386e-4f6b-bd63-af2353f3e4d8
     outputNodeGUID: ab7c80f0-51fd-401a-9d67-0b6543025f87
     inputFieldName: obj
-    outputFieldName: output
-    inputPortIdentifier: 
-    outputPortIdentifier: 
-  - GUID: 7eaf413b-f90d-42aa-a958-170655727904
-    owner: {fileID: 11400000}
-    inputNodeGUID: 9a1c513a-65bc-4906-83b7-4a7b66699064
-    outputNodeGUID: e99da4fb-6a11-4b19-8594-f37f55d96114
-    inputFieldName: inputs
-    outputFieldName: output
-    inputPortIdentifier: 
-    outputPortIdentifier: 
-  - GUID: 90f0194e-bd62-4b0c-9bff-c0cb9ee87132
-    owner: {fileID: 11400000}
-    inputNodeGUID: 9a1c513a-65bc-4906-83b7-4a7b66699064
-    outputNodeGUID: 3327402b-5ad1-4564-af17-2025a850d4bb
-    inputFieldName: inputs
     outputFieldName: output
     inputPortIdentifier: 
     outputPortIdentifier: 
@@ -93,12 +80,20 @@ MonoBehaviour:
     outputFieldName: output
     inputPortIdentifier: 
     outputPortIdentifier: 
+  - GUID: 5748fb93-7216-4454-800a-9d5d5eca5a4c
+    owner: {fileID: 11400000}
+    inputNodeGUID: 9a1c513a-65bc-4906-83b7-4a7b66699064
+    outputNodeGUID: 3327402b-5ad1-4564-af17-2025a850d4bb
+    inputFieldName: inputs
+    outputFieldName: output
+    inputPortIdentifier: 
+    outputPortIdentifier: 
   commentBlocks: []
   pinnedElements:
   - position:
       serializedVersion: 2
-      x: 824
-      y: 107
+      x: 1121
+      y: 25
       width: 142
       height: 197
     opened: 1
@@ -115,6 +110,14 @@ MonoBehaviour:
     editorType:
       serializedType: GraphProcessor.ProcessorView, com.alelievr.NodeGraphProcessor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  exposedParameters: []
-  position: {x: -30, y: 38, z: 0}
-  scale: {x: 1, y: 1, z: 1}
+  exposedParameters:
+  - guid: 4f5bc9d8-e5d3-4935-8d09-5cf903694414
+    name: Counter
+    type: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
+    serializedValue:
+      serializedType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
+      serializedName: 
+      serializedValue: 0
+    input: 1
+  position: {x: 229, y: 93, z: 0}
+  scale: {x: 0.7561437, y: 0.7561437, z: 1}

--- a/Assets/Examples/CustomOutputExample.asset
+++ b/Assets/Examples/CustomOutputExample.asset
@@ -14,32 +14,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serializedNodes:
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"ad1673a8-dc56-4495-84fa-6cd5c52f247f","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":636.6217651367188,"y":99.60122680664063,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
+    jsonDatas: '{"GUID":"ad1673a8-dc56-4495-84fa-6cd5c52f247f","computeOrder":6,"canProcess":true,"position":{"serializedVersion":"2","x":673.8209228515625,"y":130.5613555908203,"width":72.0,"height":96.0},"expanded":false,"debug":false}'
   - type: FloatNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"4ddedc62-453d-4d18-81bb-0b8cdb80556d","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":61.0,"y":329.9599914550781,"width":73.0,"height":101.0},"expanded":false,"debug":false,"output":5.0}'
+    jsonDatas: '{"GUID":"4ddedc62-453d-4d18-81bb-0b8cdb80556d","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":47.82987594604492,"y":346.8563537597656,"width":74.0,"height":101.0},"expanded":false,"debug":false,"output":5.0}'
   - type: FloatNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"54814e54-d849-427c-bd54-4f84921ddb9a","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":53.0,"y":77.0,"width":73.0,"height":101.0},"expanded":false,"debug":false,"output":42.0}'
+    jsonDatas: '{"GUID":"54814e54-d849-427c-bd54-4f84921ddb9a","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":60.04347229003906,"y":103.82608795166016,"width":73.0,"height":101.0},"expanded":false,"debug":false,"output":42.0}'
   - type: CustomPortsNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"3042d8e2-86c8-46bd-8773-a23db56c259d","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":336.0,"y":205.0,"width":141.0,"height":77.0},"expanded":false,"debug":false,"inputs":[],"outputs":[],"portCount":4}'
+    jsonDatas: '{"GUID":"3042d8e2-86c8-46bd-8773-a23db56c259d","computeOrder":5,"canProcess":true,"position":{"serializedVersion":"2","x":355.5000305175781,"y":208.1000213623047,"width":128.0,"height":221.00003051757813},"expanded":false,"debug":false,"inputs":[],"outputs":[],"portCount":7}'
   - type: FloatNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"d110a426-a040-4a9c-94f9-00c59e4f5a87","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":55.0,"y":207.0,"width":73.0,"height":101.0},"expanded":false,"debug":false,"output":0.0}'
+  - type: CircleRadians, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    jsonDatas: '{"GUID":"344fdef8-b64e-4059-9aad-c59d868c421d","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":25.35000228881836,"y":449.7000427246094,"width":116.00001525878906,"height":95.00000762939453},"expanded":true,"debug":false,"outputRadians":[]}'
   edges:
-  - GUID: 57aa4a8e-b523-4e95-bb6e-93d394c466d9
-    owner: {fileID: 11400000}
-    inputNodeGUID: ad1673a8-dc56-4495-84fa-6cd5c52f247f
-    outputNodeGUID: 3042d8e2-86c8-46bd-8773-a23db56c259d
-    inputFieldName: obj
-    outputFieldName: output
-    inputPortIdentifier: 
-    outputPortIdentifier: 
-  - GUID: add87296-72cf-4756-b69d-94982d1e08d0
-    owner: {fileID: 11400000}
-    inputNodeGUID: 3042d8e2-86c8-46bd-8773-a23db56c259d
-    outputNodeGUID: 4ddedc62-453d-4d18-81bb-0b8cdb80556d
-    inputFieldName: inputs
-    outputFieldName: output
-    inputPortIdentifier: 
-    outputPortIdentifier: 
   - GUID: de701aa2-2c35-4498-8352-293b9c90867c
     owner: {fileID: 11400000}
     inputNodeGUID: ad1673a8-dc56-4495-84fa-6cd5c52f247f
@@ -80,12 +66,20 @@ MonoBehaviour:
     outputFieldName: output
     inputPortIdentifier: 1
     outputPortIdentifier: 
+  - GUID: 22f5afb9-25a2-47d1-a971-d2fb797194b8
+    owner: {fileID: 11400000}
+    inputNodeGUID: 3042d8e2-86c8-46bd-8773-a23db56c259d
+    outputNodeGUID: 4ddedc62-453d-4d18-81bb-0b8cdb80556d
+    inputFieldName: inputs
+    outputFieldName: output
+    inputPortIdentifier: 3
+    outputPortIdentifier: 
   commentBlocks: []
   pinnedElements:
   - position:
       serializedVersion: 2
       x: 0
-      y: 139
+      y: 18
       width: 150
       height: 200
     opened: 1
@@ -94,8 +88,8 @@ MonoBehaviour:
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   - position:
       serializedVersion: 2
-      x: 873
-      y: 281
+      x: 1042
+      y: 296
       width: 150
       height: 200
     opened: 1
@@ -103,5 +97,5 @@ MonoBehaviour:
       serializedType: GraphProcessor.ProcessorView, com.alelievr.NodeGraphProcessor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
-  position: {x: 182, y: -26.5, z: 0}
-  scale: {x: 1, y: 1, z: 1}
+  position: {x: 199, y: 10, z: 0}
+  scale: {x: 0.7561437, y: 0.7561437, z: 1}

--- a/Assets/Examples/CustomPushExample.asset
+++ b/Assets/Examples/CustomPushExample.asset
@@ -16,15 +16,26 @@ MonoBehaviour:
   - type: CircleRadians, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"7078860c-f7cb-4534-befd-da3c678d17ee","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":159.0,"y":116.0,"width":116.0,"height":167.0},"expanded":false,"debug":false,"outputRadians":[0.0,1.2566370964050294,2.5132741928100588,3.769911289215088,5.026548385620117]}'
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"0d8cd048-486b-4cce-9bd3-616bd2255d45","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":496.0,"y":-3.399993896484375,"width":71.0,"height":95.0},"expanded":false,"debug":false}'
+    jsonDatas: '{"GUID":"0d8cd048-486b-4cce-9bd3-616bd2255d45","computeOrder":2,"canProcess":true,"position":{"serializedVersion":"2","x":496.0,"y":-3.399993896484375,"width":71.0,"height":95.0},"expanded":false,"debug":false}'
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"e2203ce1-49be-41ea-814a-465faf267adb","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":382.7353515625,"y":107.50852966308594,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
+    jsonDatas: '{"GUID":"e2203ce1-49be-41ea-814a-465faf267adb","computeOrder":2,"canProcess":true,"position":{"serializedVersion":"2","x":382.7353515625,"y":107.50852966308594,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"3b193543-3bd6-44d6-9664-115ecc6f2502","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":382.8052978515625,"y":239.9835205078125,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
+    jsonDatas: '{"GUID":"3b193543-3bd6-44d6-9664-115ecc6f2502","computeOrder":2,"canProcess":true,"position":{"serializedVersion":"2","x":382.8052978515625,"y":239.9835205078125,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"e3318e7b-5469-424c-ab54-9524e62907a8","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":498.0,"y":273.0,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
+    jsonDatas: '{"GUID":"e3318e7b-5469-424c-ab54-9524e62907a8","computeOrder":2,"canProcess":true,"position":{"serializedVersion":"2","x":498.0,"y":273.0,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"83c994d8-6442-4e61-82e1-e83537229fda","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":499.0,"y":137.0,"width":71.0,"height":95.0},"expanded":false,"debug":false}'
+    jsonDatas: '{"GUID":"83c994d8-6442-4e61-82e1-e83537229fda","computeOrder":2,"canProcess":true,"position":{"serializedVersion":"2","x":499.0,"y":137.0,"width":71.0,"height":95.0},"expanded":false,"debug":false}'
+  - type: ParameterNode, com.alelievr.NodeGraphProcessor, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+    jsonDatas: '{"GUID":"d892802f-ca24-46cc-8cc5-18a5ac36b09d","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":254.0,"y":-47.0,"width":100.0,"height":100.0},"expanded":false,"debug":false,"parameterGUID":"142446f1-e533-4322-8433-9c52da904d4c"}'
+  - type: MultiAddNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    jsonDatas: '{"GUID":"6b00dec7-a9af-4c2c-91fe-edb8f892882f","computeOrder":2,"canProcess":true,"position":{"serializedVersion":"2","x":734.0,"y":-220.8800048828125,"width":123.0,"height":101.0},"expanded":false,"debug":false,"output":0.0}'
+  - type: FloatNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    jsonDatas: '{"GUID":"02bc84c5-93ad-4a5e-b627-e930d133a1fd","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":394.0,"y":-219.79998779296876,"width":72.0,"height":101.0},"expanded":false,"debug":false,"output":0.0}'
+  - type: CustomPortsNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    jsonDatas: '{"GUID":"1f8d14f7-5355-4734-8837-36668dd8e8ba","computeOrder":4,"canProcess":true,"position":{"serializedVersion":"2","x":730.0,"y":-102.0,"width":128.0,"height":125.0},"expanded":false,"debug":false,"inputs":[],"outputs":[],"portCount":4}'
+  - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    jsonDatas: '{"GUID":"39f87d68-86a6-4b72-8a26-315c18d08525","computeOrder":5,"canProcess":true,"position":{"serializedVersion":"2","x":1027.0,"y":38.0,"width":100.0,"height":100.0},"expanded":false,"debug":false}'
   edges:
   - GUID: 035ee169-e916-40b5-aecc-831d072ea9ab
     owner: {fileID: 11400000}
@@ -66,6 +77,46 @@ MonoBehaviour:
     outputFieldName: outputRadians
     inputPortIdentifier: 
     outputPortIdentifier: 
+  - GUID: c7aeeeaa-b2a3-468a-8373-f9f6e4cf08a5
+    owner: {fileID: 11400000}
+    inputNodeGUID: 6b00dec7-a9af-4c2c-91fe-edb8f892882f
+    outputNodeGUID: 02bc84c5-93ad-4a5e-b627-e930d133a1fd
+    inputFieldName: inputs
+    outputFieldName: output
+    inputPortIdentifier: 
+    outputPortIdentifier: 
+  - GUID: d9874a1d-93c3-4e39-a559-cc81999c26a5
+    owner: {fileID: 11400000}
+    inputNodeGUID: 1f8d14f7-5355-4734-8837-36668dd8e8ba
+    outputNodeGUID: 02bc84c5-93ad-4a5e-b627-e930d133a1fd
+    inputFieldName: inputs
+    outputFieldName: output
+    inputPortIdentifier: 0
+    outputPortIdentifier: 
+  - GUID: 0a5a5b73-93b0-474d-94f9-24f060a1c545
+    owner: {fileID: 11400000}
+    inputNodeGUID: 1f8d14f7-5355-4734-8837-36668dd8e8ba
+    outputNodeGUID: 02bc84c5-93ad-4a5e-b627-e930d133a1fd
+    inputFieldName: inputs
+    outputFieldName: output
+    inputPortIdentifier: 1
+    outputPortIdentifier: 
+  - GUID: bc55dc8f-2a86-4f01-9bae-9ed04b041472
+    owner: {fileID: 11400000}
+    inputNodeGUID: 1f8d14f7-5355-4734-8837-36668dd8e8ba
+    outputNodeGUID: 02bc84c5-93ad-4a5e-b627-e930d133a1fd
+    inputFieldName: inputs
+    outputFieldName: output
+    inputPortIdentifier: 2
+    outputPortIdentifier: 
+  - GUID: ad729fe3-5664-4163-a4e7-825262af1996
+    owner: {fileID: 11400000}
+    inputNodeGUID: 39f87d68-86a6-4b72-8a26-315c18d08525
+    outputNodeGUID: 1f8d14f7-5355-4734-8837-36668dd8e8ba
+    inputFieldName: obj
+    outputFieldName: outputs
+    inputPortIdentifier: 
+    outputPortIdentifier: 
   commentBlocks: []
   pinnedElements:
   - position:
@@ -78,6 +129,26 @@ MonoBehaviour:
     editorType:
       serializedType: GraphProcessor.ProcessorView, com.alelievr.NodeGraphProcessor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-  exposedParameters: []
-  position: {x: 58, y: 149, z: 0}
+  - position:
+      serializedVersion: 2
+      x: 20
+      y: 51
+      width: 150
+      height: 200
+    opened: 1
+    editorType:
+      serializedType: GraphProcessor.ExposedParameterView, com.alelievr.NodeGraphProcessor,
+        Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  exposedParameters:
+  - guid: 142446f1-e533-4322-8433-9c52da904d4c
+    name: New ColorParam
+    type: UnityEngine.Color, UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+    serializedValue:
+      serializedType: UnityEngine.Color, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+      serializedName: 
+      serializedValue: '{"r":0.0,"g":0.0,"b":0.0,"a":0.0}'
+    input: 1
+  position: {x: 58, y: 266, z: 0}
   scale: {x: 1, y: 1, z: 1}

--- a/Assets/Examples/DefaultNodes/Nodes/CustomPortsNode.cs
+++ b/Assets/Examples/DefaultNodes/Nodes/CustomPortsNode.cs
@@ -17,8 +17,10 @@ public class CustomPortsNode : BaseNode
 
 	public override string		name => "CustomPorts";
 
-	// We keep the max port count so it doesn't cause binding issues
-	[SerializeField, HideInInspector]
+    public override string      layoutStyle => "TestType";
+
+    // We keep the max port count so it doesn't cause binding issues
+    [SerializeField, HideInInspector]
 	int							portCount = 1;
 
 	protected override void Process()

--- a/Assets/Examples/ExposedPropertiesExample.asset
+++ b/Assets/Examples/ExposedPropertiesExample.asset
@@ -11,7 +11,7 @@ MonoBehaviour:
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 31390c44c9f3a3d40b424bf6821999a2, type: 3}
   m_Name: ExposedPropertiesExample
-  m_EditorClassIdentifier:
+  m_EditorClassIdentifier: 
   serializedNodes:
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"39fdf09f-b7ff-49f5-bfe5-c59e221c30b6","computeOrder":2,"canProcess":true,"position":{"serializedVersion":"2","x":227.00003051757813,"y":445.00006103515627,"width":72.0,"height":95.0},"expanded":true,"debug":false}'
@@ -30,7 +30,7 @@ MonoBehaviour:
     outputNodeGUID: 8bd321f8-b93c-4360-8b0c-d004d3604e97
     inputFieldName: obj
     outputFieldName: output
-    inputPortIdentifier:
+    inputPortIdentifier: 
     outputPortIdentifier: output
   - GUID: 3cab5bf1-528f-4325-849e-d82233fc7f62
     owner: {fileID: 11400000}
@@ -38,7 +38,7 @@ MonoBehaviour:
     outputNodeGUID: dab6d88a-b3dc-4dc9-bd5f-1240771222bf
     inputFieldName: obj
     outputFieldName: output
-    inputPortIdentifier:
+    inputPortIdentifier: 
     outputPortIdentifier: output
   commentBlocks: []
   pinnedElements:
@@ -68,7 +68,7 @@ MonoBehaviour:
     type: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
     serializedValue:
       serializedType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
-      serializedName:
+      serializedName: 
       serializedValue: 42
     input: 1
   - guid: 9ae7b637-72eb-4fcf-90d9-c9bd11336a2b
@@ -76,7 +76,7 @@ MonoBehaviour:
     type: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
     serializedValue:
       serializedType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
-      serializedName:
+      serializedName: 
       serializedValue: 21
     input: 1
   - guid: fc2400e0-1461-4ba2-9d60-9533b6417d88
@@ -86,8 +86,8 @@ MonoBehaviour:
     serializedValue:
       serializedType: UnityEngine.Color, UnityEngine.CoreModule, Version=0.0.0.0,
         Culture=neutral, PublicKeyToken=null
-      serializedName:
+      serializedName: 
       serializedValue: '{"r":1.0,"g":0.0,"b":0.0,"a":0.0}'
     input: 1
-  position: {x: 255, y: -577, z: 0}
-  scale: {x: 1.3225, y: 1.3225, z: 1}
+  position: {x: 405, y: -285, z: 0}
+  scale: {x: 0.8695652, y: 0.8695652, z: 1}

--- a/Assets/Examples/GraphProcessor.asset
+++ b/Assets/Examples/GraphProcessor.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   serializedNodes:
   - type: PrefabNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"d0e22884-b7b2-4000-9fbd-89787c0a2546","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":392.0,"y":210.0,"width":82.0,"height":159.0},"expanded":false,"debug":false,"output":{"fileID":1636575971871760,"guid":"f78111bdbdeaf6644806fc49fcaf1d30","type":3}}'
+    jsonDatas: '{"GUID":"d0e22884-b7b2-4000-9fbd-89787c0a2546","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":455.37054443359377,"y":113.31758880615235,"width":136.0,"height":224.0},"expanded":false,"debug":false,"output":{"fileID":1636575971871760,"guid":"f78111bdbdeaf6644806fc49fcaf1d30","type":3}}'
   edges: []
   commentBlocks: []
   pinnedElements:
@@ -29,5 +29,5 @@ MonoBehaviour:
       serializedType: GraphProcessor.ExposedParameterView, com.alelievr.NodeGraphProcessor,
         Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   exposedParameters: []
-  position: {x: 0, y: -12, z: 0}
-  scale: {x: 1, y: 1, z: 1}
+  position: {x: -120, y: -76, z: 0}
+  scale: {x: 1.3225, y: 1.3225, z: 1}

--- a/Assets/Examples/Resources/TestType.uss
+++ b/Assets/Examples/Resources/TestType.uss
@@ -1,0 +1,3 @@
+#title {
+    background-color: rgba(59, 94, 68, 0.8);
+}

--- a/Assets/Examples/Resources/TestType.uss.meta
+++ b/Assets/Examples/Resources/TestType.uss.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 4b8544e277509f945b7a95d04bc07470
+ScriptedImporter:
+  fileIDToRecycleName:
+    11400000: stylesheet
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Resources/GraphProcessorStyles/BaseNodeView.uss
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Resources/GraphProcessorStyles/BaseNodeView.uss
@@ -1,7 +1,10 @@
 #node {
-    background-color: rgba(0, 63, 63, 0.8);
+    background-color: rgba(0, 63,63, 0.8);
 }
 
 #controls {
     background-color: rgba(63, 63, 63, 0.8);
+}
+#title {
+    background-color: rgba(59, 83, 94, 0.8);
 }

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
@@ -44,7 +44,10 @@ namespace GraphProcessor
 
 			owner.computeOrderUpdated += ComputeOrderUpdatedCallback;
 
-			styleSheets.Add(Resources.Load<StyleSheet>(baseNodeStyle));
+            styleSheets.Add(Resources.Load<StyleSheet>(baseNodeStyle));
+
+            if (!string.IsNullOrEmpty(node.layoutStyle))
+                styleSheets.Add(Resources.Load<StyleSheet>(node.layoutStyle));
 
 			InitializePorts();
 			InitializeView();

--- a/Assets/com.alelievr.NodeGraphProcessor/Runtime/Elements/BaseNode.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Runtime/Elements/BaseNode.cs
@@ -15,6 +15,8 @@ namespace GraphProcessor
 	{
 		public virtual string       name => GetType().Name;
 
+        public virtual string       layoutStyle => string.Empty;
+
 		//id
 		public string				GUID;
 

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.1.3f1
-m_EditorVersionWithRevision: 2019.1.3f1 (dc414eb9ed43)
+m_EditorVersion: 2019.1.0f2
+m_EditorVersionWithRevision: 2019.1.0f2 (292b93d75a2c)


### PR DESCRIPTION
A virtual string implemented called **layoutStyle**.
In derived classes, you can override it with a custom uss file. This way individual node types can have individual styles such as different title colors. 

System checks **layoutStyle** property then it adds it on top of default node style, this way user only have to define style elements that they want as follows in BaseNodeView.cs:


            

            styleSheets.Add(Resources.Load<StyleSheet>(baseNodeStyle));
            if (!string.IsNullOrEmpty(node.layoutStyle))
                styleSheets.Add(Resources.Load<StyleSheet>(node.layoutStyle));
For example they don't have to write down this in every custom node style like this:
`#node {
    background-color: rgba(0, 63,63, 0.8);
}`

Instead they can just define what they want to, such as title:
`#title {
    background-color: rgba(59, 94, 68, 0.8);
}`
