### PR TITLE
Auto addition of selections to comment block

### DIFF
--- a/Assets/Examples/BasicExample.asset
+++ b/Assets/Examples/BasicExample.asset
@@ -18,13 +18,13 @@ MonoBehaviour:
   - type: FloatNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"3327402b-5ad1-4564-af17-2025a850d4bb","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":242.0,"y":101.0,"width":73.0,"height":101.0},"expanded":false,"debug":false,"output":4.0}'
   - type: MultiAddNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"9a1c513a-65bc-4906-83b7-4a7b66699064","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":406.8500061035156,"y":121.50003051757813,"width":123.00001525878906,"height":101.0},"expanded":false,"debug":false,"output":0.0}'
+    jsonDatas: '{"GUID":"9a1c513a-65bc-4906-83b7-4a7b66699064","computeOrder":2,"canProcess":true,"position":{"serializedVersion":"2","x":406.64605712890627,"y":244.3121337890625,"width":125.0,"height":101.0},"expanded":false,"debug":false,"output":0.0}'
   - type: SubNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"95bce55f-47d9-4c5d-bdcd-1f5bbbf57d1b","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":710.0,"y":200.0,"width":99.0,"height":101.0},"expanded":false,"debug":false,"inputA":0.0,"inputB":8.0,"output":-8.0}'
+    jsonDatas: '{"GUID":"95bce55f-47d9-4c5d-bdcd-1f5bbbf57d1b","computeOrder":4,"canProcess":true,"position":{"serializedVersion":"2","x":709.6460571289063,"y":322.3121337890625,"width":98.0,"height":101.0},"expanded":false,"debug":false,"inputA":0.0,"inputB":8.0,"output":-8.0}'
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"42eb43b8-ac7e-4f38-b49b-26ba1bc42732","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":879.1253051757813,"y":151.1937713623047,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
+    jsonDatas: '{"GUID":"42eb43b8-ac7e-4f38-b49b-26ba1bc42732","computeOrder":5,"canProcess":true,"position":{"serializedVersion":"2","x":879.1253051757813,"y":151.1937713623047,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"6398414c-0e45-44d7-a62f-3267016dbca1","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":236.43923950195313,"y":-42.947715759277347,"width":99.0,"height":115.0},"expanded":false,"debug":false}'
+    jsonDatas: '{"GUID":"6398414c-0e45-44d7-a62f-3267016dbca1","computeOrder":2,"canProcess":true,"position":{"serializedVersion":"2","x":236.43923950195313,"y":-42.947715759277347,"width":99.0,"height":115.0},"expanded":false,"debug":false}'
   - type: PrefabNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"ffd2cf4b-87c3-42a6-9822-04bae7a5700b","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":478.04730224609377,"y":-235.4877471923828,"width":136.0,"height":223.00001525878907},"expanded":true,"debug":false,"output":{"instanceID":0}}'
   - type: FloatNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
@@ -33,9 +33,9 @@ MonoBehaviour:
     jsonDatas: '{"GUID":"ab7c80f0-51fd-401a-9d67-0b6543025f87","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":-104.5,"y":125.5,"width":73.0,"height":113.0},"expanded":false,"debug":false,"output":"Hello
       World"}'
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"e277d5c6-386e-4f6b-bd63-af2353f3e4d8","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":68.76971435546875,"y":94.11068725585938,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
+    jsonDatas: '{"GUID":"e277d5c6-386e-4f6b-bd63-af2353f3e4d8","computeOrder":2,"canProcess":true,"position":{"serializedVersion":"2","x":68.76971435546875,"y":94.11068725585938,"width":107.0,"height":117.0},"expanded":false,"debug":false}'
   - type: FloatNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"34e17a0c-9187-47eb-a21c-d105ee6ed911","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":506.0,"y":309.04254150390627,"width":107.0,"height":117.0},"expanded":true,"debug":false,"output":8.0}'
+    jsonDatas: '{"GUID":"34e17a0c-9187-47eb-a21c-d105ee6ed911","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":505.64605712890627,"y":431.3121337890625,"width":73.0,"height":101.0},"expanded":true,"debug":false,"output":8.0}'
   - type: ParameterNode, com.alelievr.NodeGraphProcessor, Version=0.0.0.0, Culture=neutral,
       PublicKeyToken=null
     jsonDatas: '{"GUID":"eb62aec1-6b04-49a1-89c4-27d66f83289d","computeOrder":1,"canProcess":true,"position":{"serializedVersion":"2","x":631.0,"y":6.160011291503906,"width":88.0,"height":77.0},"expanded":false,"debug":false,"parameterGUID":"4f5bc9d8-e5d3-4935-8d09-5cf903694414"}'
@@ -88,7 +88,20 @@ MonoBehaviour:
     outputFieldName: output
     inputPortIdentifier: 
     outputPortIdentifier: 
-  commentBlocks: []
+  commentBlocks:
+  - title: New Comment Block
+    color: {r: 0, g: 0, b: 0, a: 0}
+    position:
+      serializedVersion: 2
+      x: 381.64612
+      y: 164.31215
+      width: 451
+      height: 392.99997
+    size: {x: 300, y: 100}
+    innerNodeGUIDs:
+    - 9a1c513a-65bc-4906-83b7-4a7b66699064
+    - 95bce55f-47d9-4c5d-bdcd-1f5bbbf57d1b
+    - 34e17a0c-9187-47eb-a21c-d105ee6ed911
   pinnedElements:
   - position:
       serializedVersion: 2
@@ -119,5 +132,5 @@ MonoBehaviour:
       serializedName: 
       serializedValue: 0
     input: 1
-  position: {x: 229, y: 93, z: 0}
-  scale: {x: 0.7561437, y: 0.7561437, z: 1}
+  position: {x: 421, y: 215, z: 0}
+  scale: {x: 0.65751624, y: 0.65751624, z: 1}

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
@@ -260,7 +260,7 @@ namespace GraphProcessor
 		protected void BuildCreateContextualMenu(ContextualMenuPopulateEvent evt)
 		{
 			Vector2 position = evt.mousePosition - (Vector2)viewTransform.position;
-            evt.menu.AppendAction("Create/Comment Block", (e) => AddCommentBlock(new CommentBlock("New Comment Block", position)), DropdownMenuAction.AlwaysEnabled);
+            evt.menu.AppendAction("Create/Comment Block", (e) => AddSelectionsToCommentBlock(AddCommentBlock(new CommentBlock("New Comment Block", position))), DropdownMenuAction.AlwaysEnabled);
 		}
 
 		protected void BuildViewContextualMenu(ContextualMenuPopulateEvent evt)
@@ -489,14 +489,14 @@ namespace GraphProcessor
 			nodeViewsPerNode.Clear();
 		}
 
-        public void AddCommentBlock(CommentBlock block)
+        public CommentBlockView AddCommentBlock(CommentBlock block)
         {
             graph.AddCommentBlock(block);
             block.OnCreated();
-            AddCommentBlockView(block);
+            return AddCommentBlockView(block);
         }
 
-		public void AddCommentBlockView(CommentBlock block)
+		public CommentBlockView AddCommentBlockView(CommentBlock block)
 		{
 			var c = new CommentBlockView();
 
@@ -505,7 +505,22 @@ namespace GraphProcessor
 			AddElement(c);
 
             commentBlockViews.Add(c);
+            return c;
 		}
+
+        public void AddSelectionsToCommentBlock(CommentBlockView view)
+        {
+            foreach (var selectedNode in selection)
+            {
+                if (selectedNode is BaseNodeView)
+                {
+                    if (commentBlockViews.Exists(x => x.ContainsElement(selectedNode as BaseNodeView)))
+                        continue;
+
+                    view.AddElement(selectedNode as BaseNodeView);
+                }
+            }
+        }
 
 		public void RemoveCommentBlocks()
 		{


### PR DESCRIPTION
In shadergraph and vfx graph, if you have nodes selected and you right click to add a comment block, it automatically put those nodes into your block.
This PR basically does this.

Changes:
1. **AddCommentBlock** and **AddCommentBlockView** method types changed to _CommentBlockView_
2. **AddSelectionsToCommentView** method added, it gets this return type and adds _selections_ to commentView
3. **BuildCreateContextualMenu** method's menu callback is added as follows:
`AddSelectionsToCommentView(AddCommentBlock(....`

**Edit: Merge conflicts resolved**