### PR TITLE
Node position locking/unlocking support

### DIFF
--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
@@ -33,7 +33,9 @@ namespace GraphProcessor
 		public event Action< PortView >			onPortConnected;
 		public event Action< PortView >			onPortDisconnected;
 
-		readonly string							baseNodeStyle = "GraphProcessorStyles/BaseNodeView";
+        public bool initializing = false; //Used for applying SetPosition on locked node at init.
+
+        readonly string							baseNodeStyle = "GraphProcessorStyles/BaseNodeView";
 
 		#region  Initialization
 
@@ -84,7 +86,9 @@ namespace GraphProcessor
 
 			title = (string.IsNullOrEmpty(nodeTarget.name)) ? nodeTarget.GetType().Name : nodeTarget.name;
 
-			SetPosition(nodeTarget.position);
+            initializing = true;
+
+            SetPosition(nodeTarget.position);
 		}
 
 		void InitializeDebug()
@@ -264,10 +268,14 @@ namespace GraphProcessor
 
 		public override void SetPosition(Rect newPos)
 		{
-			base.SetPosition(newPos);
+            if (initializing || !nodeTarget.isLocked)
+            {
+                initializing = false;
+                base.SetPosition(newPos);
 
-			Undo.RegisterCompleteObjectUndo(owner.graph, "Moved graph node");
-			nodeTarget.position = newPos;
+                Undo.RegisterCompleteObjectUndo(owner.graph, "Moved graph node");
+                nodeTarget.position = newPos;
+            }
 		}
 
 		public override bool	expanded
@@ -280,14 +288,26 @@ namespace GraphProcessor
 			}
 		}
 
-		public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)
+        public void ChangeLockStatus()
+        {
+            nodeTarget.nodeLock ^= true;
+        }
+
+        public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)
 		{
 			evt.menu.AppendAction("Open Node Script", (e) => OpenNodeScript(), OpenNodeScriptStatus);
 			evt.menu.AppendAction("Open Node View Script", (e) => OpenNodeViewScript(), OpenNodeViewScriptStatus);
 			evt.menu.AppendAction("Debug", (e) => ToggleDebug(), DebugStatus);
-		}
+            if (nodeTarget.unlockable)
+                evt.menu.AppendAction((nodeTarget.isLocked ? "Unlock" : "Lock"), (e) => ChangeLockStatus(), LockStatus);
+        }
 
-		Status DebugStatus(DropdownMenuAction action)
+        Status LockStatus(DropdownMenuAction action)
+        {
+            return Status.Normal;
+        }
+
+        Status DebugStatus(DropdownMenuAction action)
 		{
 			if (nodeTarget.debug)
 				return Status.Checked;

--- a/Assets/com.alelievr.NodeGraphProcessor/Runtime/Elements/BaseNode.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Runtime/Elements/BaseNode.cs
@@ -17,8 +17,12 @@ namespace GraphProcessor
 
         public virtual string       layoutStyle => string.Empty;
 
-		//id
-		public string				GUID;
+        public virtual bool         unlockable => true; 
+
+        public virtual bool         isLocked => nodeLock; 
+
+        //id
+        public string				GUID;
 
 		public int					computeOrder = -1;
 		public bool					canProcess = true;
@@ -32,8 +36,9 @@ namespace GraphProcessor
 		public Rect					position;
 		public bool					expanded;
 		public bool					debug;
+        public bool                 nodeLock;
 
-		public delegate void		ProcessDelegate();
+        public delegate void		ProcessDelegate();
 
 		public event ProcessDelegate	onProcessed;
 


### PR DESCRIPTION
## Summary
So for locking/unlocking,
Right click over a node->Lock/Unlock node to disable dragging of nodes.
**This allows you to have locked immovable nodes by default**

![image](https://user-images.githubusercontent.com/3215742/60524700-b6d76200-9cf5-11e9-8969-9733919f96f8.png)
 ## Description 
Sometimes locking node positions become handy in order to not to unintentionally drag nodes. 
So I've added locking ability. Also custom nodes can override it and have locked/unlocked by default.
Also custom nodes can override locking/unlocking ability.
So, a node can be immovable and can't be unlocked(if overrided virtual bools) or can be movable and can't be locked.
## For Custom Nodes
![image](https://user-images.githubusercontent.com/3215742/60524747-cf477c80-9cf5-11e9-9aaa-17bae1ab0b35.png)
**isLocked:** Default lock status(Is locked by default or not)
**unlockable:** Is that node unlockable


