### PR TITLE
Make graphView on EdgeConnectorListener protected

### DIFF
--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Logic/EdgeConnectorListener.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Logic/EdgeConnectorListener.cs
@@ -11,7 +11,7 @@ namespace GraphProcessor
     /// </summary>
     public class BaseEdgeConnectorListener : IEdgeConnectorListener
     {
-        readonly BaseGraphView graphView;
+        protected readonly BaseGraphView graphView;
 
         Dictionary< Edge, PortView >    edgeInputPorts = new Dictionary< Edge, PortView >();
         Dictionary< Edge, PortView >    edgeOutputPorts = new Dictionary< Edge, PortView >();


### PR DESCRIPTION
Exposing this to subclasses is handy so they don't have to cache the graph view themselves.