### PR TITLE
Fixes Cloned PinnedElements in GraphView and GroupView ContextualMenu

### DIFF
--- a/Assets/Examples/BasicExample.asset
+++ b/Assets/Examples/BasicExample.asset
@@ -41,10 +41,7 @@ MonoBehaviour:
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"42bd42f7-7c33-4d6c-8cff-24e051b0e644","computeOrder":12,"position":{"serializedVersion":"2","x":88.17012786865235,"y":211.09640502929688,"width":74.0,"height":90.0},"expanded":false,"debug":false,"nodeLock":false}'
   - type: FloatNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-    jsonDatas: '{"GUID":"c647797a-972a-442d-86fe-327825c1fe11","computeOrder":14,"position":{"serializedVersion":"2","x":347.8111267089844,"y":446.6003723144531,"width":108.00000762939453,"height":101.0},"expanded":false,"debug":false,"nodeLock":false,"output":0.0,"input":0.0}'
-  - type: RelayNode, com.alelievr.NodeGraphProcessor.Runtime, Version=0.0.0.0, Culture=neutral,
-      PublicKeyToken=null
-    jsonDatas: '{"GUID":"e896146f-3f81-490d-85e4-18ffdb60f87c","computeOrder":13,"position":{"serializedVersion":"2","x":174.81114196777345,"y":426.6003723144531,"width":200.0,"height":200.0},"expanded":false,"debug":false,"nodeLock":false,"unpackOutput":false,"inputEdgeCount":0}'
+    jsonDatas: '{"GUID":"c647797a-972a-442d-86fe-327825c1fe11","computeOrder":13,"position":{"serializedVersion":"2","x":347.8111267089844,"y":446.6003723144531,"width":108.00000762939453,"height":101.0},"expanded":false,"debug":false,"nodeLock":false,"output":0.0,"input":0.0}'
   - type: CustomPortData, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
     jsonDatas: '{"GUID":"acf42c0b-dc50-476f-8d14-b9e756fd1e2d","computeOrder":15,"position":{"serializedVersion":"2","x":605.9840087890625,"y":456.5184020996094,"width":115.0,"height":149.0},"expanded":false,"debug":false,"nodeLock":false,"output":0.0}'
   - type: PrintNode, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
@@ -98,14 +95,6 @@ MonoBehaviour:
     outputFieldName: output
     inputPortIdentifier: 
     outputPortIdentifier: 
-  - GUID: 8076c785-67a2-4fb8-87f0-867d022b8da6
-    owner: {fileID: 11400000}
-    inputNodeGUID: c647797a-972a-442d-86fe-327825c1fe11
-    outputNodeGUID: e896146f-3f81-490d-85e4-18ffdb60f87c
-    inputFieldName: input
-    outputFieldName: output
-    inputPortIdentifier: 
-    outputPortIdentifier: 0
   - GUID: 46622e62-ce25-420f-8a6f-3211fb51fdac
     owner: {fileID: 11400000}
     inputNodeGUID: 0bb81f44-19ac-4b15-a7a6-f0f319a6d5c7
@@ -252,7 +241,7 @@ MonoBehaviour:
     input: 1
     settings:
       isHidden: 0
-  position: {x: -78, y: -181, z: 0}
+  position: {x: 299, y: 85, z: 0}
   scale: {x: 0.8695652, y: 0.8695652, z: 1}
   references:
     version: 1

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Resources/GraphProcessorStyles/GroupView.uss
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Resources/GraphProcessorStyles/GroupView.uss
@@ -3,3 +3,7 @@
     margin: 8px;
     width: 50px;
 }
+
+#titleContainer > #titleLabel, #titleContainer > #titleField {
+    margin-left: 55px;
+}

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
@@ -626,9 +626,9 @@ namespace GraphProcessor
 
 		public void ClearGraphElements()
 		{
+			RemoveGroups();
 			RemoveNodeViews();
 			RemoveEdges();
-			RemoveGroups();
 			RemoveStackNodeViews();
 			RemovePinnedElementViews();
 		}

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
@@ -599,7 +599,7 @@ namespace GraphProcessor
 			{
 				SaveGraphToDisk();
 				// Close pinned windows from old graph:
-				pinnedElements.Clear();
+				ClearGraphElements();
 			}
 
 			this.graph = graph;

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/GroupView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/GroupView.cs
@@ -83,6 +83,16 @@ namespace GraphProcessor
             base.OnElementsAdded(elements);
         }
 
+        protected override void OnElementsRemoved(IEnumerable<GraphElement> elements)
+        {
+            foreach (var elem in elements)
+            {
+                if (elem is BaseNodeView nodeView)
+                    group.innerNodeGUIDs.Remove(nodeView.nodeTarget.GUID);
+            }
+            base.OnElementsRemoved(elements);
+        }
+
         public void UpdateGroupColor(Color newColor)
         {
             group.color = newColor;

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/GroupView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/GroupView.cs
@@ -22,7 +22,9 @@ namespace GraphProcessor
         {
             styleSheets.Add(Resources.Load<StyleSheet>(groupStyle));
 		}
-
+		
+		private static void BuildContextualMenu(ContextualMenuPopulateEvent evt) {}
+		
 		public void Initialize(BaseGraphView graphView, Group block)
 		{
 			group = block;
@@ -30,7 +32,9 @@ namespace GraphProcessor
 
             title = block.title;
             SetPosition(block.position);
-
+			
+			this.AddManipulator(new ContextualMenuManipulator(BuildContextualMenu));
+			
             headerContainer.Q<TextField>().RegisterCallback<ChangeEvent<string>>(TitleChangedCallback);
             titleLabel = headerContainer.Q<Label>();
 

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/GroupView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/GroupView.cs
@@ -85,11 +85,18 @@ namespace GraphProcessor
 
         protected override void OnElementsRemoved(IEnumerable<GraphElement> elements)
         {
-            foreach (var elem in elements)
+            // Only remove the nodes when the group exists in the hierarchy
+            if (parent != null)
             {
-                if (elem is BaseNodeView nodeView)
-                    group.innerNodeGUIDs.Remove(nodeView.nodeTarget.GUID);
+                foreach (var elem in elements)
+                {
+                    if (elem is BaseNodeView nodeView)
+                    {
+                        group.innerNodeGUIDs.Remove(nodeView.nodeTarget.GUID);
+                    }
+                }
             }
+
             base.OnElementsRemoved(elements);
         }
 


### PR DESCRIPTION
- When re-opening any graph view when it is still open, pinned elements wouldn't destroyed from the graph view. So, every time we open the same graph, it adds same pinned elements again and again. This fixes it.
- When a group view is added, we couldn't delete it from the graph. So, added the contextual menu to it.
- Little visual improvements for group view title. So now the title don't collide with the color picker.

--------
By the way, there are some problems related to both Group View and Stack Nodes that I couldn't successfully fix.

For example, If you drag-out a node from a group with shift key pressed, it successfully detaches from the group; but when you re-open the same graph, you'll see this node in the group again. I tried to use OnElementsRemoved in GroupView, but when re-opening any graph all group nodes are detaches even the graph asset file shows (I mean, I see correct GUIDs in the Group) they're attached (somehow, when opening a graph, OnElementsRemoved triggered and all nodes from the group detaches).

And for the stack node, I couldn't simple detach all child nodes from the stack. It simply removes all child nodes when you delete the stack node (which is understandable UX, but I think the opposite is more usable).

I would like to fix these problems, but I need some help =) I couldn't find any solution.