### PR TITLE
Add USS child IDs to childs of Stack Node

### DIFF
--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseStackNodeView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseStackNodeView.cs
@@ -47,13 +47,17 @@ namespace GraphProcessor
 
         void InitializeInnerNodes()
         {
+            int i = 0;
             // Sanitize the GUID list in case some nodes were removed
             stackNode.nodeGUIDs.RemoveAll(nodeGUID =>
             {
                 if (owner.graph.nodesPerGUID.ContainsKey(nodeGUID))
                 {
                     var node = owner.graph.nodesPerGUID[nodeGUID];
-                    AddElement(owner.nodeViewsPerNode[node]);
+                    var view = owner.nodeViewsPerNode[node];
+                    view.AddToClassList("stack-child__" + i);
+                    i++;
+                    AddElement(view);
                     return false;
                 }
                 else


### PR DESCRIPTION
Allows to color nodes differently based on their position in the Stack, since USS seems to not have CSS selectors such as "first-child".

![image](https://user-images.githubusercontent.com/2693840/92337328-18891e00-f0a9-11ea-8b89-53582d7539d6.png)

Up for discussion:
- should it be numbered
- should it follow the [names outlined here](https://docs.unity3d.com/Manual/UIE-USS-WritingStyleSheets.html)
  - stack-node__first-child, stack-node__other-child