### PR TITLE
Fix inconsistent field drawer behavior

### DIFF
--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
@@ -728,6 +728,11 @@ namespace GraphProcessor
 					controlsContainer.Add(element);
 				}
 			}
+			else
+			{
+				// Make sure we create an empty placeholder if FieldFactory can not provide a drawer
+				if (showInputDrawer) AddEmptyField(field, false);
+			}
 
 			var visibleCondition = field.GetCustomAttribute(typeof(VisibleIf)) as VisibleIf;
 			if (visibleCondition != null)

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
@@ -556,7 +556,13 @@ namespace GraphProcessor
 		
 		protected virtual void DrawDefaultInspector(bool fromInspector = false)
 		{
-			var fields = nodeTarget.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+			var fields = nodeTarget.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+				// Filter fields from the BaseNode type since we are only interested in user-defined fields
+				// (better than BindingFlags.DeclaredOnly because we keep any inherited user-defined fields) 
+				.Where(f => f.DeclaringType != typeof(BaseNode))
+				// Order by MetadataToken to sync the order with the port order (make sure FieldDrawers are next to the correct port)
+				//TODO: Also consider custom port order
+				.OrderBy(f => f.MetadataToken);
 
 			foreach (var field in fields)
 			{


### PR DESCRIPTION
Attempts to fix #116 

1. Fields that use the `[SerializeField]` attribute but are not supported by `FieldFactory` create an empty placeholder element to keep the field drawer position in sync with the ports
2. User-defined, inherited fields are considered during `BaseNodeView.DrawDefaultInspector` and the fields are re-ordered to match the default port order

I haven't yet fully grasped how port ordering works. I assume this method won't work for nodes that use custom port ordering. For me it works great on simple nodes even with inheritance. 