### PR TITLE
Add support for node accent colors

### DIFF
--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
@@ -155,8 +155,15 @@ namespace GraphProcessor
 				mainContainer.Add(debugContainer);
 
 			title = (string.IsNullOrEmpty(nodeTarget.name)) ? nodeTarget.GetType().Name : nodeTarget.name;
+			
+			// Apply node accent color
+			if (nodeTarget.color.a > 0)
+			{
+				titleContainer.style.borderBottomColor = new StyleColor(nodeTarget.color);
+				titleContainer.style.borderBottomWidth = new StyleFloat(5f);
+			}
 
-            initializing = true;
+			initializing = true;
 
             SetPosition(nodeTarget.position);
 

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
@@ -156,17 +156,11 @@ namespace GraphProcessor
 
 			title = (string.IsNullOrEmpty(nodeTarget.name)) ? nodeTarget.GetType().Name : nodeTarget.name;
 			
-			// Apply node accent color
-			if (nodeTarget.color.a > 0)
-			{
-				titleContainer.style.borderBottomColor = new StyleColor(nodeTarget.color);
-				titleContainer.style.borderBottomWidth = new StyleFloat(5f);
-			}
-
 			initializing = true;
 
             SetPosition(nodeTarget.position);
-
+			SetNodeColor(nodeTarget.color);
+            
 			AddInputContainer();
 		}
 
@@ -634,6 +628,12 @@ namespace GraphProcessor
 			}
 		}
 
+		protected virtual void SetNodeColor(Color color)
+		{
+			titleContainer.style.borderBottomColor = new StyleColor(color);
+			titleContainer.style.borderBottomWidth = new StyleFloat(color.a > 0 ? 5f : 0f);
+		}
+		
 		private void AddEmptyField(FieldInfo field, bool fromInspector)
 		{
 			if(field.GetCustomAttribute(typeof(InputAttribute)) == null || fromInspector) return;

--- a/Assets/com.alelievr.NodeGraphProcessor/Runtime/Elements/BaseNode.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Runtime/Elements/BaseNode.cs
@@ -19,7 +19,12 @@ namespace GraphProcessor
 		/// </summary>
 		/// <returns></returns>
 		public virtual string       name => GetType().Name;
-
+		
+		/// <summary>
+		/// The accent color of the node
+		/// </summary>
+		public virtual Color color => Color.clear;
+		
 		/// <summary>
 		/// Set a custom uss file for the node. We use a Resources.Load to get the stylesheet so be sure to put the correct resources path
 		/// https://docs.unity3d.com/ScriptReference/Resources.Load.html


### PR DESCRIPTION
Implements #118

The node color is a property of `BaseNode` and can be overridden by the user for each node. `BaseNodeView` implements a virtual method `SetNodeColor` to make the change on the UIElements container. Users could also override `SetNodeColor` to implement a different accent color effect (eg. gradient or coloring the entire node header).