### PR TITLE
Implement custom node-based Conversions

### DIFF
--- a/Assets/Examples/DefaultNodes/Nodes/FloatToStringNode.cs
+++ b/Assets/Examples/DefaultNodes/Nodes/FloatToStringNode.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Globalization;
+using GraphProcessor;
+using UnityEngine;
+
+[Serializable, NodeMenuItem("Convert/Float to String"), ConverterNode(typeof(float), typeof(string))]
+public class FloatToStringsNode : BaseNode, IConversionNode
+{
+	[Input("In")]
+	public float input;
+
+	public int decimalPlaces = 2;
+
+	[Output("Out")]
+	public string output;
+
+	public override string name => "To String";
+
+	public string GetConversionInput()
+	{
+		return nameof(input);
+	}
+
+	public string GetConversionOutput()
+	{
+		return nameof(output);
+	}
+
+	protected override void Process()
+	{
+		var mult = Mathf.Pow(10, decimalPlaces);
+		float val = Mathf.Round(input * mult) / mult;
+		output = val.ToString(CultureInfo.InvariantCulture);
+	}
+}

--- a/Assets/Examples/DefaultNodes/Nodes/FloatToStringNode.cs.meta
+++ b/Assets/Examples/DefaultNodes/Nodes/FloatToStringNode.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5947dfd18c94461281d83969aff7d203
+timeCreated: 1643494663

--- a/Assets/Examples/Editor/GraphAssetCallbacks.cs
+++ b/Assets/Examples/Editor/GraphAssetCallbacks.cs
@@ -9,7 +9,7 @@ using System.IO;
 public class GraphAssetCallbacks
 {
 	[MenuItem("Assets/Create/GraphProcessor", false, 10)]
-	public static void CreateGraphPorcessor()
+	public static void CreateGraphProcessor()
 	{
 		var graph = ScriptableObject.CreateInstance< BaseGraph >();
 		ProjectWindowUtil.CreateAsset(graph, "GraphProcessor.asset");

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Logic/EdgeConnectorListener.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Logic/EdgeConnectorListener.cs
@@ -64,7 +64,7 @@ namespace GraphProcessor
             try
             {
                 this.graphView.RegisterCompleteObjectUndo("Connected " + edgeView.input.node.name + " and " + edgeView.output.node.name);
-                if (!this.graphView.Connect(edge as EdgeView, autoDisconnectInputs: !wasOnTheSamePort))
+                if (!this.graphView.ConnectConvertable(edge as EdgeView, !wasOnTheSamePort))
                     this.graphView.Disconnect(edge as EdgeView);
             } catch (System.Exception)
             {

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Utils/NodeProvider.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Utils/NodeProvider.cs
@@ -337,9 +337,18 @@ namespace GraphProcessor
 			{
 				if ((portView.direction == Direction.Input && description.isInput) || (portView.direction == Direction.Output && !description.isInput))
 					return false;
+
+				if (portView.direction == Direction.Input)
+				{
+					if (!BaseGraph.TypesAreConnectable(description.portType, portView.portType))
+						return false;
+				}
+				else
+				{
+					if (!BaseGraph.TypesAreConnectable( portView.portType, description.portType))
+						return false;
+				}
 	
-				if (!BaseGraph.TypesAreConnectable(description.portType, portView.portType))
-					return false;
 					
 				return true;
 			}

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
@@ -779,7 +779,7 @@ namespace GraphProcessor
 			{
 				var interfaces = nodeInfo.type.GetInterfaces();
                 var exceptInheritedInterfaces = interfaces.Except(interfaces.SelectMany(t => t.GetInterfaces()));
-				foreach (var i in interfaces)
+				foreach (var i in exceptInheritedInterfaces)
 				{
 					if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICreateNodeFrom<>))
 					{

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
@@ -430,7 +430,7 @@ namespace GraphProcessor
 		{
 			var compatiblePorts = new List< Port >();
 
-			compatiblePorts.AddRange(ports.ToList().Where(p => {
+			compatiblePorts.AddRange(ports.Where(p => {
 				var portView = p as PortView;
 
 				if (portView.owner == (startPort as PortView).owner)

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseGraphView.cs
@@ -812,7 +812,8 @@ namespace GraphProcessor
 
 		void UpdateSerializedProperties()
 		{
-			serializedGraph = new SerializedObject(graph);
+			if(graph != null)
+				serializedGraph = new SerializedObject(graph);
 		}
 
 		/// <summary>

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
@@ -835,6 +835,9 @@ namespace GraphProcessor
 			var nodeIndexString = nodeIndex.ToString();
 			foreach (var propertyField in this.Query<PropertyField>().ToList())
 			{
+				if(!propertyField.enabledSelf || propertyField.bindingPath == null)
+					continue;
+				
 				propertyField.Unbind();
 				// The property path look like this: nodes.Array.data[x].fieldName
 				// And we want to update the value of x with the new node index:

--- a/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Editor/Views/BaseNodeView.cs
@@ -835,7 +835,7 @@ namespace GraphProcessor
 			var nodeIndexString = nodeIndex.ToString();
 			foreach (var propertyField in this.Query<PropertyField>().ToList())
 			{
-				if(!propertyField.enabledSelf || propertyField.bindingPath == null)
+				if(propertyField.bindingPath == null)
 					continue;
 				
 				propertyField.Unbind();

--- a/Assets/com.alelievr.NodeGraphProcessor/Runtime/Elements/BaseNode.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Runtime/Elements/BaseNode.cs
@@ -376,7 +376,10 @@ namespace GraphProcessor
 			if (fieldInfo.behavior != null)
 			{
 				foreach (var portData in fieldInfo.behavior(edges))
-					AddPortData(portData);
+				{
+					if (portData != null)
+						AddPortData(portData);
+				}
 			}
 			else
 			{

--- a/Assets/com.alelievr.NodeGraphProcessor/Runtime/Elements/NodePort.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Runtime/Elements/NodePort.cs
@@ -194,7 +194,7 @@ namespace GraphProcessor
 
 // We keep slow checks inside the editor
 #if UNITY_EDITOR
-				if (!BaseGraph.TypesAreConnectable(inputField.FieldType, outputField.FieldType))
+				if (!BaseGraph.TypesAreConnectable(outputField.FieldType, inputField.FieldType))
 				{
 					Debug.LogError("Can't convert from " + inputField.FieldType + " to " + outputField.FieldType + ", you must specify a custom port function (i.e CustomPortInput or CustomPortOutput) for non-implicit convertions");
 					return null;
@@ -207,14 +207,14 @@ namespace GraphProcessor
 				inType = edge.inputPort.portData.displayType ?? inputField.FieldType;
 				outType = edge.outputPort.portData.displayType ?? outputField.FieldType;
 
-				// If there is a user defined convertion function, then we call it
+				// If there is a user defined conversion function, then we call it
 				if (TypeAdapter.AreAssignable(outType, inType))
 				{
 					// We add a cast in case there we're calling the conversion method with a base class parameter (like object)
 					var convertedParam = Expression.Convert(outputParamField, outType);
-					outputParamField = Expression.Call(TypeAdapter.GetConvertionMethod(outType, inType), convertedParam);
+					outputParamField = Expression.Call(TypeAdapter.GetConversionMethod(outType, inType), convertedParam);
 					// In case there is a custom port behavior in the output, then we need to re-cast to the base type because
-					// the convertion method return type is not always assignable directly:
+					// the conversion method return type is not always assignable directly:
 					outputParamField = Expression.Convert(outputParamField, inputField.FieldType);
 				}
 				else // otherwise we cast

--- a/Assets/com.alelievr.NodeGraphProcessor/Runtime/Graph/BaseGraph.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Runtime/Graph/BaseGraph.cs
@@ -823,27 +823,30 @@ namespace GraphProcessor
 		/// <summary>
 		/// Tell if two types can be connected in the context of a graph
 		/// </summary>
-		/// <param name="t1"></param>
-		/// <param name="t2"></param>
+		/// <param name="from"></param>
+		/// <param name="to"></param>
 		/// <returns></returns>
-		public static bool TypesAreConnectable(Type t1, Type t2)
+		public static bool TypesAreConnectable(Type from, Type to) // NOTE: Extend this later for adding conversion nodes
 		{
-			if (t1 == null || t2 == null)
+			if (from == null || to == null)
 				return false;
 
-			if (TypeAdapter.AreIncompatible(t1, t2))
+			if (TypeAdapter.AreIncompatible(from, to))
 				return false;
 
 			//Check if there is custom adapters for this assignation
-			if (CustomPortIO.IsAssignable(t1, t2))
+			if (CustomPortIO.IsAssignable(from, to))
 				return true;
 
 			//Check for type assignability
-			if (t2.IsReallyAssignableFrom(t1))
+			if (to.IsReallyAssignableFrom(from))
 				return true;
 
-			// User defined type convertions
-			if (TypeAdapter.AreAssignable(t1, t2))
+			// User defined type conversions
+			if (TypeAdapter.AreAssignable(from, to))
+				return true;
+
+			if (ConversionNodeAdapter.AreAssignable(from, to))
 				return true;
 
 			return false;

--- a/Assets/com.alelievr.NodeGraphProcessor/Runtime/Processing/CustomPortIO.cs
+++ b/Assets/com.alelievr.NodeGraphProcessor/Runtime/Processing/CustomPortIO.cs
@@ -79,15 +79,15 @@ namespace GraphProcessor
 					deleg = Expression.Lambda< CustomPortIODelegate >(ex, p1, p2, p3).Compile();
 #endif
 
-					if (deleg == null)
-					{
-						Debug.LogWarning("Can't use custom IO port function " + method + ": The method have to respect this format: " + typeof(CustomPortIODelegate));
-						continue ;
-					}
-
 					string fieldName = (portInputAttr == null) ? portOutputAttr.fieldName : portInputAttr.fieldName;
 					Type customType = (portInputAttr == null) ? portOutputAttr.outputType : portInputAttr.inputType;
-					Type fieldType = type.GetField(fieldName, bindingFlags).FieldType;
+					var field = type.GetField(fieldName, bindingFlags);
+					if (field == null)
+					{
+						Debug.LogWarning("Can't use custom IO port function '" + method.Name + "' of class '" + type.Name + "': No field named " + fieldName + " found");
+						continue ;
+					}
+					Type fieldType = field.FieldType;
 
 					AddCustomIOMethod(type, fieldName, deleg);
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NodeGraphProcessor
+# NodeGraphProcessor Fork
 Node graph editor framework focused on data processing using Unity UIElements, GraphView and C# 4.7
 
 [![Discord](https://img.shields.io/discord/823720615965622323.svg)](https://discord.gg/XuMd3Z5Rym)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NodeGraphProcessor Fork
+# NodeGraphProcessor
 Node graph editor framework focused on data processing using Unity UIElements, GraphView and C# 4.7
 
 [![Discord](https://img.shields.io/discord/823720615965622323.svg)](https://discord.gg/XuMd3Z5Rym)


### PR DESCRIPTION
I implemented custom converter nodes with this branch. These nodes are automatically added when a user connects two ports that are convertible through by a node. I created the FloatToStringsNode to give an example of how this feature can be used. To test it out try to connect a 'Sub' node to the log input of the 'Console Log' node. You will see that the FloatToStringsNode is added inbetween to do the conversion from float to int automatically. This feature can be very useful in some cases, since some conversions rely on additional info given by the user, as shown by my example node. 
Conversions now do not need to be symmetrical, as I reordered some parameters in the conversion checking to always be the right way around. This should fix what issue #173 talked about. 
Additionally, some small fixes are implemented, mostly regarding nullreference exceptions. Also some small typos in the README. Some error messages were also made much clearer.
Sorry for bundling this all together into one large pull request. I dont use git a lot so this was the easiest way for me.