### PR TITLE
Fixed renaming feature for nodes

### DIFF
--- a/Editor/Views/BaseNodeView.cs
+++ b/Editor/Views/BaseNodeView.cs
@@ -211,7 +211,6 @@ namespace GraphProcessor
 				titleTextField.focusable = true;
 
 				titleTextField.SetValueWithoutNotify(title);
-				titleTextField.SelectAll();
 				
 				titleTextField.schedule.Execute(() =>
 				{

--- a/Editor/Views/BaseNodeView.cs
+++ b/Editor/Views/BaseNodeView.cs
@@ -211,8 +211,13 @@ namespace GraphProcessor
 				titleTextField.focusable = true;
 
 				titleTextField.SetValueWithoutNotify(title);
-				titleTextField.Focus();
 				titleTextField.SelectAll();
+				
+				titleTextField.schedule.Execute(() =>
+				{
+					titleTextField.Focus();
+					titleTextField.SelectAll();
+				});
 			}
 
 			void CloseAndSaveTitleEditor(string newTitle)


### PR DESCRIPTION
The renaming wasn't working, FocusOut event was firing right after the TextField was appearing, I made the Focus method call delayed and it fixed the issue, renaming works again now. 

Unity: 6000.2.9f1
Package Version: 1.3.1